### PR TITLE
envisage-23149  - feat: date-only sorting and case-insensitive __name field ordering

### DIFF
--- a/graphene_django_filter/connection_field.py
+++ b/graphene_django_filter/connection_field.py
@@ -7,6 +7,8 @@ module instead of the `DjangoFilterConnectionField` from graphene-django.
 import warnings
 from typing import Any, Callable, Dict, Iterable, Optional, Type, Union
 
+from django.db.models.functions import TruncDate
+
 import graphene
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -118,6 +120,12 @@ class AdvancedDjangoFilterConnectionField(DjangoFilterConnectionField):
                 snake_order = to_snake_case(order)
             else:
                 snake_order = [to_snake_case(o) for o in order]
+
+            # If `created_date` is requested, annotate a date-only truncation of
+            # `created_on` so can be sort by day without timestamp.
+            has_created_date = any(f.lstrip("-") == "created_date" for f in snake_order)
+            if has_created_date:
+                qs = qs.annotate(created_date=TruncDate("created_on"))
 
             # annotate counts for ordering
             for order_arg in snake_order:

--- a/graphene_django_filter/connection_field.py
+++ b/graphene_django_filter/connection_field.py
@@ -7,7 +7,7 @@ module instead of the `DjangoFilterConnectionField` from graphene-django.
 import warnings
 from typing import Any, Callable, Dict, Iterable, Optional, Type, Union
 
-from django.db.models.functions import TruncDate
+from django.db.models.functions import Lower,TruncDate
 
 import graphene
 from django.core.exceptions import ValidationError
@@ -122,7 +122,7 @@ class AdvancedDjangoFilterConnectionField(DjangoFilterConnectionField):
                 snake_order = [to_snake_case(o) for o in order]
 
             # If `created_date` is requested, annotate a date-only truncation of
-            # `created_on` so can be sort by day without timestamp.
+            # `created_on` so it can be sorted by day without the timestamp.
             has_created_date = any(f.lstrip("-") == "created_date" for f in snake_order)
             if has_created_date:
                 qs = qs.annotate(created_date=TruncDate("created_on"))
@@ -145,6 +145,24 @@ class AdvancedDjangoFilterConnectionField(DjangoFilterConnectionField):
             queryset=qs,
             request=info.context,
         )
-        if filterset.form.is_valid():
-            return filterset.qs
-        raise ValidationError(filterset.form.errors.as_json())
+        if not filterset.form.is_valid():
+            raise ValidationError(filterset.form.errors.as_json())
+
+        result = filterset.qs
+
+        # case-insensitive ordering for any `__name` fields after the filterset runs
+        if order:
+            name_fields = [f for f in snake_order if f.lstrip("-").endswith("__name")]
+            if name_fields:
+                final_order = []
+                for field in snake_order:
+                    bare = field.lstrip("-")
+                    if bare.endswith("__name"):
+                        annotation_key = "lower_" + bare.replace("__", "_")
+                        result = result.annotate(**{annotation_key: Lower(bare)})
+                        final_order.append(f"-{annotation_key}" if field.startswith("-") else annotation_key)
+                    else:
+                        final_order.append(field)
+                result = result.order_by(*final_order)
+
+        return result


### PR DESCRIPTION
## Problem
Two ordering issues in `resolve_queryset`:

1. **Timestamp bleed in date sorting** — sorting by `created_on` compared full timestamps, so components created on the same calendar day were not treated as equal (e.g. 03:02:47 vs 18:52:41 produced unexpected ordering within the same day).

2. **Case-sensitive FK name sorting** — sorting by fields like `component_type__name` used ASCII byte order, causing uppercase letters to always sort before lowercase (e.g. `Episode → Prop → fdsfafd` instead of `Episode → fdsfafd → Prop`).

## Solution

### Date-only sorting
- When `created_date` is used in `orderBy`, annotates a `TruncDate("created_on")` computed field
- Allows grouping by calendar day before applying secondary sort keys

### Case-insensitive `__name` sorting
- Detects any `orderBy` field ending in `__name`
- Annotates a `Lower(field)` value and substitutes it into the final `order_by`
- Ensures alphabetical ordering is case-insensitive across FK traversals

## Changes
- `graphene_django_filter/connection_field.py`
  - Import `Lower` and `TruncDate` from `django.db.models.functions`
  - Annotate `created_date` via `TruncDate` when requested
  - Post-filterset: detect `__name` fields, annotate lowercased versions, rewrite order
